### PR TITLE
Resolved mismatch stubbings in AemConfigTest.java

### DIFF
--- a/src/test/java/com/shinesolutions/aemorchestrator/config/AemConfigTest.java
+++ b/src/test/java/com/shinesolutions/aemorchestrator/config/AemConfigTest.java
@@ -98,6 +98,7 @@ public class AemConfigTest {
         String elasticLoadBalancerNameForAuthor = "elasticLoadBalancerNameForAuthor";
         setField(aemConfig, "awsAuthorStackName", awsAuthorStackName);
         setField(aemConfig, "awsAuthorLoadBalancerLogicalId", awsAuthorLoadBalancerLogicalId);
+        when(awsHelperService.getStackPhysicalResourceId("awsAuthorStackName", "awsAuthorLoadBalancerLogicalId")).thenReturn(null);
         when(awsHelperService.getElbName(
           awsHelperService.getStackPhysicalResourceId(
                   awsAuthorStackName,
@@ -193,6 +194,7 @@ public class AemConfigTest {
         String elasticLoadBalancerNameForAuthor = "elasticLoadBalancerNameForAuthor";
         setField(aemConfig, "awsAuthorStackName", awsAuthorStackName);
         setField(aemConfig, "awsAuthorLoadBalancerLogicalId", awsAuthorLoadBalancerLogicalId);
+        when(awsHelperService.getStackPhysicalResourceId("awsAuthorStackName", "awsAuthorLoadBalancerLogicalId")).thenReturn(null);
         when(awsHelperService.getElbName(
           awsHelperService.getStackPhysicalResourceId(
                   awsAuthorStackName,


### PR DESCRIPTION
I analyzed the test doubles (mocks) in the test code of the project. In my analysis of the project, I observed that

In tests `testEnvValueStandardArchitecture` and `testEnvValuePreviewArchitecture`:

* The `getStackPhysicalResourceId` method for the `awsHelperService` object:
i) during test execution the method is actually called with arguments `["awsAuthorStackName", "awsAuthorLoadBalancerLogicalId"]`, but is not stubbed, resulting in a mismatch stubbing

In general, a mismatched stubbing occurs when a method is stubbed with specific arguments in a test but later invoked with different arguments in the code. Mockito recommends addressing this type of issue (https://www.javadoc.io/doc/org.mockito/mockito-core/latest/org.mockito/org/mockito/exceptions/misusing/PotentialStubbingProblem.html).

I propose a solution below to resolve the mismatch stubbing. Happy to modify the pull request based on your feedback.